### PR TITLE
remove dev and staging envs for staff-sso

### DIFF
--- a/config/staff-sso.yaml
+++ b/config/staff-sso.yaml
@@ -3,22 +3,6 @@ name: staff-sso
 namespace: datahub
 scm: git@github.com:uktrade/staff-sso.git
 environments:
-  - environment: dev
-    type: gds
-    app: dit-staging/dev-datahub/staff-sso-dev
-    vars:
-      - HERE: 1
-    secrets: true
-    run:
-      - "true"
-  - environment: staging
-    type: gds
-    app: dit-staging/staging-datahub/staff-sso-staging
-    vars:
-      - HERE: 1
-    secrets: true
-    run:
-      - "true"
   - environment: prod
     type: gds
     app: dit-services/datahub/staff-sso


### PR DESCRIPTION
Dev and staging are currently not needed - staging is in heroku and we don't have a dev env.  